### PR TITLE
Add simple macro dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-OK this is gonna be the github repo for our macro dashboard
+# Macro Dashboard
+
+This repository contains a simple Streamlit application that displays key U.S. macroeconomic indicators using data from the FRED database.
+
+## Requirements
+
+Install the dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the Streamlit app with:
+
+```bash
+streamlit run dashboard.py
+```
+
+The app shows line charts for non-farm payrolls, CPI, PCE, the Fed funds rate and the 10-year Treasury yield. A sidebar lists upcoming release dates for major indicators.

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,0 +1,37 @@
+import streamlit as st
+import pandas as pd
+import pandas_datareader.data as web
+from datetime import datetime
+
+st.title('Macro Economic Dashboard')
+
+# Fetch data from FRED
+start = datetime(2010, 1, 1)
+end = datetime.today()
+
+series = {
+    'Non-Farm Payrolls (PAYEMS)': 'PAYEMS',
+    'CPI (CPIAUCSL)': 'CPIAUCSL',
+    'PCE (PCE)': 'PCE',
+    'Fed Funds Rate (FEDFUNDS)': 'FEDFUNDS',
+    '10Y Treasury (DGS10)': 'DGS10',
+}
+
+@st.cache_data
+def load_data(symbol):
+    return web.DataReader(symbol, 'fred', start, end)
+
+data_frames = {name: load_data(code) for name, code in series.items()}
+
+# Plot line charts
+for name, df in data_frames.items():
+    st.subheader(name)
+    st.line_chart(df)
+
+# Upcoming events
+st.sidebar.header('Upcoming Releases')
+calendar = pd.DataFrame({
+    'Event': ['Non-Farm Payrolls', 'CPI Release', 'FOMC Meeting'],
+    'Date': ['2024-09-06', '2024-09-12', '2024-09-18']
+})
+st.sidebar.table(calendar)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+streamlit
+pandas
+pandas_datareader


### PR DESCRIPTION
## Summary
- implement `dashboard.py` using Streamlit to plot FRED macro data
- add `requirements.txt` for dependencies
- update README with setup and usage instructions

## Testing
- `python3 -m py_compile dashboard.py`
- `pip install -r requirements.txt`
- `streamlit run dashboard.py --server.headless true --server.port 8501`

------
https://chatgpt.com/codex/tasks/task_e_68581c856758832abff1272dc10d33a3