### PR TITLE
Add fallback entry point for running Streamlit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # Macro Dashboard
 
-This repository contains a simple Streamlit application that displays key U.S. macroeconomic indicators using data from the FRED database.
+This Streamlit application visualizes key U.S. macroeconomic indicators using live data from the FRED and BLS APIs.
 
 ## Requirements
-
-Install the dependencies with:
 
 ```bash
 pip install -r requirements.txt
@@ -12,10 +10,17 @@ pip install -r requirements.txt
 
 ## Usage
 
-Run the Streamlit app with:
+Set a `FRED_API_KEY` environment variable if you need access to restricted FRED
+series and run:
 
 ```bash
 streamlit run dashboard.py
 ```
 
-The app shows line charts for non-farm payrolls, CPI, PCE, the Fed funds rate and the 10-year Treasury yield. A sidebar lists upcoming release dates for major indicators.
+If the `streamlit` command is unavailable, you can instead launch the app with:
+
+```bash
+python dashboard.py
+```
+
+The dashboard displays metrics for employment, inflation and interest rates along with trend charts and a small events sidebar.

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,37 +1,177 @@
-import streamlit as st
-import pandas as pd
-import pandas_datareader.data as web
+"""Streamlit-based US macroeconomic dashboard using live API data.
+
+This app fetches macroeconomic indicators from FRED and the BLS public API
+and visualizes recent trends.  A FRED API key can be supplied via the
+``FRED_API_KEY`` environment variable for series that require it.
+"""
+
+from __future__ import annotations
+
+import os
 from datetime import datetime
 
-st.title('Macro Economic Dashboard')
+import altair as alt
+import pandas as pd
+import pandas_datareader.data as web
+import requests
+import streamlit as st
 
-# Fetch data from FRED
-start = datetime(2010, 1, 1)
-end = datetime.today()
+START_DATE = datetime(2018, 1, 1)
 
-series = {
-    'Non-Farm Payrolls (PAYEMS)': 'PAYEMS',
-    'CPI (CPIAUCSL)': 'CPIAUCSL',
-    'PCE (PCE)': 'PCE',
-    'Fed Funds Rate (FEDFUNDS)': 'FEDFUNDS',
-    '10Y Treasury (DGS10)': 'DGS10',
+
+@st.cache_data(show_spinner=False)
+def fetch_fred(series: str) -> pd.DataFrame:
+    """Return a DataFrame for a given FRED series."""
+    try:
+        df = web.DataReader(series, "fred", START_DATE, datetime.today())
+        df = df.reset_index().rename(columns={series: "value", "DATE": "date"})
+        return df
+    except Exception:
+        # fallback to FRED API if pandas_datareader fails
+        api_key = st.secrets.get("FRED_API_KEY") or os.getenv("FRED_API_KEY")
+        if not api_key:
+            raise
+        url = "https://api.stlouisfed.org/fred/series/observations"
+        params = {
+            "series_id": series,
+            "api_key": api_key,
+            "file_type": "json",
+            "observation_start": START_DATE.strftime("%Y-%m-%d"),
+        }
+        r = requests.get(url, params=params, timeout=20)
+        r.raise_for_status()
+        out = pd.DataFrame(r.json()["observations"])
+        out["date"] = pd.to_datetime(out["date"])
+        out["value"] = pd.to_numeric(out["value"], errors="coerce")
+        return out[["date", "value"]]
+
+
+@st.cache_data(show_spinner=False)
+def fetch_bls(series_id: str) -> pd.DataFrame:
+    """Fetch a monthly series from the BLS public API."""
+    payload = {
+        "seriesid": [series_id],
+        "startyear": START_DATE.year,
+        "endyear": datetime.today().year,
+    }
+    url = "https://api.bls.gov/publicAPI/v2/timeseries/data/"
+    r = requests.post(url, json=payload, timeout=20)
+    r.raise_for_status()
+    series = r.json()["Results"]["series"][0]["data"]
+    rows = []
+    for item in series:
+        if item["period"] == "M13":  # annual
+            continue
+        month = int(item["period"][1:])
+        date = pd.to_datetime(f"{item['year']}-{month:02d}-01")
+        rows.append({"date": date, "value": float(item["value"])})
+    df = pd.DataFrame(rows).sort_values("date")
+    return df
+
+
+st.set_page_config(page_title="US Macro Dashboard", layout="wide")
+
+# Load series
+series_map = {
+    "PAYEMS": "Non-Farm Payrolls (thous)",
+    "UNRATE": "Unemployment Rate (%)",
+    "CES0500000003": "Avg Hourly Earnings (USD)",
+    "CPIAUCSL": "CPI",
+    "CPILFESL": "Core CPI",
+    "PCEPI": "PCE",
+    "PCEPILFE": "Core PCE",
+    "FEDFUNDS": "Fed Funds Rate",
 }
 
-@st.cache_data
-def load_data(symbol):
-    return web.DataReader(symbol, 'fred', start, end)
+fred_ids = ["CPIAUCSL", "CPILFESL", "PCEPI", "PCEPILFE", "FEDFUNDS"]
+bls_ids = ["PAYEMS", "UNRATE", "CES0500000003"]
 
-data_frames = {name: load_data(code) for name, code in series.items()}
+data_frames = {}
+for sid in fred_ids:
+    data_frames[sid] = fetch_fred(sid)
+for sid in bls_ids:
+    data_frames[sid] = fetch_bls(sid)
 
-# Plot line charts
-for name, df in data_frames.items():
-    st.subheader(name)
-    st.line_chart(df)
+# Compute derived metrics
+cpi = data_frames["CPIAUCSL"].set_index("date")
+cpi["yoy"] = cpi["value"].pct_change(12) * 100
+cpi["mom"] = cpi["value"].pct_change() * 100
+core_cpi = data_frames["CPILFESL"].set_index("date")
+core_cpi["yoy"] = core_cpi["value"].pct_change(12) * 100
+core_cpi["mom"] = core_cpi["value"].pct_change() * 100
+pce = data_frames["PCEPI"].set_index("date")
+pce["yoy"] = pce["value"].pct_change(12) * 100
+core_pce = data_frames["PCEPILFE"].set_index("date")
+core_pce["yoy"] = core_pce["value"].pct_change(12) * 100
 
-# Upcoming events
-st.sidebar.header('Upcoming Releases')
-calendar = pd.DataFrame({
-    'Event': ['Non-Farm Payrolls', 'CPI Release', 'FOMC Meeting'],
-    'Date': ['2024-09-06', '2024-09-12', '2024-09-18']
-})
-st.sidebar.table(calendar)
+# Latest metrics
+latest = {}
+for sid, df in data_frames.items():
+    latest[sid] = df.iloc[-1]["value"]
+    if len(df) > 1:
+        latest[f"prev_{sid}"] = df.iloc[-2]["value"]
+    else:
+        latest[f"prev_{sid}"] = float("nan")
+
+st.title("US Macro Dashboard")
+
+cols = st.columns(4)
+for i, sid in enumerate(series_map.keys()):
+    val = latest[sid]
+    prev = latest.get(f"prev_{sid}", float("nan"))
+    delta = val - prev if pd.notna(prev) else None
+    with cols[i % 4]:
+        st.metric(series_map[sid], f"{val:.2f}", delta=None if delta is None else f"{delta:.2f}")
+
+st.subheader("Inflation Trends")
+infl_df = pd.DataFrame({
+    "date": cpi.index,
+    "CPI YoY": cpi["yoy"],
+    "Core CPI YoY": core_cpi["yoy"],
+    "PCE YoY": pce["yoy"],
+    "Core PCE YoY": core_pce["yoy"],
+}).melt("date", var_name="series", value_name="value")
+chart = (
+    alt.Chart(infl_df)
+    .mark_line()
+    .encode(x="date:T", y="value:Q", color="series:N")
+    .properties(height=300)
+)
+st.altair_chart(chart, use_container_width=True)
+
+st.subheader("Fed Funds Rate")
+rate_chart = (
+    alt.Chart(data_frames["FEDFUNDS"])
+    .mark_line(color="orange")
+    .encode(x="date:T", y="value:Q")
+)
+st.altair_chart(rate_chart, use_container_width=True)
+
+st.subheader("CPI vs Fed Funds Rate")
+combo = (
+    alt.Chart(cpi.reset_index())
+    .mark_line(color="steelblue")
+    .encode(x="date:T", y="yoy:Q")
+    +
+    alt.Chart(data_frames["FEDFUNDS"])
+    .mark_line(color="orange")
+    .encode(x="date:T", y="value:Q")
+)
+st.altair_chart(combo, use_container_width=True)
+
+with st.sidebar:
+    st.header("Upcoming Events")
+    events = pd.DataFrame(
+        {
+            "Event": ["FOMC Meeting", "NFP Release", "CPI Release"],
+            "Date": ["2025-07-30", "2025-07-05", "2025-07-11"],
+        }
+    )
+    st.table(events)
+
+if __name__ == "__main__":
+    import sys
+    import streamlit.web.cli as stcli
+
+    sys.argv = ["streamlit", "run", __file__]
+    sys.exit(stcli.main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 streamlit
 pandas
 pandas_datareader
+altair
+requests


### PR DESCRIPTION
## Summary
- document alternative way to launch the app when the `streamlit` command isn't on the path
- import `os` and add `__main__` guard so `python dashboard.py` launches via `streamlit`

## Testing
- `python -m py_compile dashboard.py`
- `streamlit run dashboard.py`

------
https://chatgpt.com/codex/tasks/task_e_6858441856b8832ab370ad2c3801ecfd