### PR TITLE
Refactor FRED retrieval to requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Macro Dashboard
 
 This Streamlit application visualizes key U.S. macroeconomic indicators using live data from the FRED and BLS APIs.
+All FRED series are retrieved directly via the FRED REST API using the ``requests`` library.
 
 ## Requirements
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 streamlit
 pandas
-pandas_datareader
 altair
 requests


### PR DESCRIPTION
## Summary
- fetch FRED data with the REST API directly
- drop pandas_datareader dependency
- document FRED REST usage in README

## Testing
- `python -m py_compile dashboard.py`

------
https://chatgpt.com/codex/tasks/task_e_685850259a94832aba9e9c4b62cd8518