### PR TITLE
Add economic calendar sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ pip install -r requirements.txt
 
 ## Usage
 
-Set a `FRED_API_KEY` environment variable (or provide it in
-`.streamlit/secrets.toml` when using Streamlit Cloud) if you need access to
-restricted FRED series and run:
+Set `FRED_API_KEY` and `TRADING_ECON_API_KEY` environment variables (or provide
+them in `.streamlit/secrets.toml` when using Streamlit Cloud) if you need
+access to restricted FRED series or a personal Trading Economics key and run:
 
 ```bash
 streamlit run dashboard.py
@@ -25,4 +25,4 @@ If the `streamlit` command is unavailable, you can instead launch the app with:
 python dashboard.py
 ```
 
-The dashboard displays metrics for employment, inflation and interest rates along with trend charts and a small events sidebar.
+The dashboard displays metrics for employment, inflation and interest rates along with trend charts and a sidebar showing a 14‑day economic calendar.


### PR DESCRIPTION
## Summary
- pull economic calendar for next 14 days using Trading Economics API
- show upcoming events in the sidebar grouped by day
- highlight FOMC Meeting, NFP and ADP events
- document new `TRADING_ECON_API_KEY` option

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_686a473524cc832a9e6010a2259d6daa