### PR TITLE
Improve calendar error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ pip install -r requirements.txt
 
 ## Usage
 
-Set a `FRED_API_KEY` environment variable (or provide it in
-`.streamlit/secrets.toml` when using Streamlit Cloud) if you need access to
-restricted FRED series and run:
+Set `FRED_API_KEY` and `TRADING_ECON_API_KEY` environment variables (or provide
+them in `.streamlit/secrets.toml` when using Streamlit Cloud) if you need
+access to restricted FRED series or a personal Trading Economics key and run:
 
 ```bash
 streamlit run dashboard.py
@@ -25,4 +25,9 @@ If the `streamlit` command is unavailable, you can instead launch the app with:
 python dashboard.py
 ```
 
-The dashboard displays metrics for employment, inflation and interest rates along with trend charts and a small events sidebar.
+The dashboard displays metrics for employment, inflation and interest rates along with trend charts and a sidebar showing a 14‑day U.S. economic calendar of high‑importance events. Key items such as FOMC meetings, Non Farm Payrolls, ADP Employment changes and CPI releases are highlighted.
+
+Note that the default `guest:guest` key and many free accounts only return a
+limited snapshot of events and may exclude U.S. data entirely. If the sidebar is
+empty, verify that your `TRADING_ECON_API_KEY` grants access to United States
+calendar entries.

--- a/dashboard.py
+++ b/dashboard.py
@@ -9,7 +9,7 @@ for Streamlit Cloud deployments.
 from __future__ import annotations
 
 import os
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import altair as alt
 import pandas as pd
@@ -80,6 +80,66 @@ def fetch_bls(series_id: str) -> pd.DataFrame:
     if not rows:
         return pd.DataFrame(columns=["date", "value"])
     return pd.DataFrame(rows).sort_values("date")
+
+
+CALENDAR_COLUMNS = [
+    "Date",
+    "Country",
+    "Event",
+    "Actual",
+    "Forecast",
+    "TEForecast",
+    "Previous",
+    "Importance",
+    "date_only",
+    "time",
+]
+
+
+@st.cache_data(show_spinner=False)
+def fetch_calendar() -> pd.DataFrame:
+    """Return upcoming U.S. economic events using the Trading Economics API."""
+    api_key = _get_secret("TRADING_ECON_API_KEY") or "guest:guest"
+    today = datetime.utcnow().date()
+    end = today + timedelta(days=14)
+    params = {
+        "c": api_key,
+        "start": today.strftime("%Y-%m-%d"),
+        "end": end.strftime("%Y-%m-%d"),
+        "importance": 3,
+        "format": "json",
+    }
+    url = (
+        "https://api.tradingeconomics.com/calendar/country/"
+        "united states"
+    )
+    try:
+        r = requests.get(url, params=params, timeout=20)
+        if r.status_code == 403:
+            # Key lacks access to U.S. events
+            return pd.DataFrame(columns=CALENDAR_COLUMNS)
+        r.raise_for_status()
+        data = r.json()
+    except Exception:
+        data = []
+
+    if not isinstance(data, list):
+        data = []
+
+    df = pd.DataFrame(data)
+    if df.empty:
+        return pd.DataFrame(columns=CALENDAR_COLUMNS)
+
+    df = df[df.get("Country") == "United States"]
+    df = df[df.get("Importance") == 3]
+    df["Date"] = pd.to_datetime(df.get("Date"), errors="coerce")
+    df["date_only"] = df["Date"].dt.date
+    df["time"] = df["Date"].dt.strftime("%H:%M")
+    for col in CALENDAR_COLUMNS:
+        if col not in df.columns:
+            df[col] = pd.NA
+    df = df.sort_values("Date")
+    return df[CALENDAR_COLUMNS]
 
 
 
@@ -268,14 +328,45 @@ st.altair_chart(combo_chart, use_container_width=True)
 
 
 with st.sidebar:
-    st.header("Upcoming Events")
-    events = pd.DataFrame(
-        {
-            "Event": ["FOMC Meeting", "NFP Release", "CPI Release"],
-            "Date": ["2025-07-30", "2025-07-05", "2025-07-11"],
-        }
-    )
-    st.table(events)
+    st.header("Economic Calendar (next 14 days)")
+    calendar_df = fetch_calendar()
+    if "date_only" not in calendar_df.columns:
+        calendar_df["date_only"] = pd.NaT
+    if calendar_df.empty or calendar_df["Date"].max() < pd.Timestamp.utcnow():
+        st.info(
+            "No U.S. events were retrieved. Free or guest API keys may not "
+            "include United States data. Verify your `TRADING_ECON_API_KEY` "
+            "permissions."
+        )
+    start = datetime.utcnow().date()
+    for day in pd.date_range(start, periods=14):
+        st.subheader(day.strftime("%b %d, %Y"))
+        day_events = calendar_df[calendar_df["date_only"] == day.date()]
+        if day_events.empty:
+            st.write("No events scheduled")
+            continue
+        for _, ev in day_events.sort_values("Date").iterrows():
+            def _fmt(x):
+                return x if x not in (None, "") else "N/A"
+
+            actual = _fmt(ev.get("Actual"))
+            forecast = _fmt(ev.get("Forecast") or ev.get("TEForecast"))
+            previous = _fmt(ev.get("Previous"))
+            time = ev.get("time") or ""
+            importance = int(ev.get("Importance", 1))
+            dots = "\u2022" * importance
+            event_title = ev.get("Event", "") or ""
+            highlight = event_title in [
+                "FOMC Meeting",
+                "Non Farm Payrolls",
+                "ADP Employment Change",
+            ] or "CPI" in event_title
+            style = "color:#ff4b4b;font-weight:bold;" if highlight else ""
+            title = f"<span style='{style}'>{ev.get('Event')}</span>"
+            st.markdown(
+                f"{dots} {time} {ev.get('Country')} - {title}<br>Actual: {actual} | Forecast: {forecast} | Previous: {previous}",
+                unsafe_allow_html=True,
+            )
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
## Summary
- clarify limited U.S. access for some Trading Economics keys
- handle 403 responses in `fetch_calendar`
- show sidebar warning when API key lacks U.S. access
- filter calendar to Importance 3 events and highlight CPI

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_686a473524cc832a9e6010a2259d6daa